### PR TITLE
Fix azerbaijani parameter name

### DIFF
--- a/ms-CEESpring2024.py
+++ b/ms-CEESpring2024.py
@@ -756,7 +756,7 @@ class BasicBot(
                 'sr': 'држава', 'tt': 'ил', 'tr': 'ülke', 'uk': 'країна', 'hr': 'zemlja', 'hy': 'երկիր', 'kk': 'ел',
                 'en': 'country', 'uz': 'mamlakat', }
     # local name for topic parameter
-    topicp = {'pl': 'parametr', 'az': 'qadınlar', 'ba': 'тема', 'be': 'тэма', 'be-tarask': 'тэма', 'bg': 'тема',
+    topicp = {'pl': 'parametr', 'az': 'mövzu', 'ba': 'тема', 'be': 'тэма', 'be-tarask': 'тэма', 'bg': 'тема',
               'bs': 'tema', 'de': 'thema', 'crh': 'mevzu', 'el': 'topic', 'et': 'teema', 'eo': 'temo',
               'hu': 'téma', 'ka': 'თემა', 'lv': 'tēma', 'lt': 'tema', 'mk': 'тема', 'myv': 'тема',
               'ro': 'secțiune', 'roa-rup': 'тема', 'ru': 'тема', 'sah': 'тиэмэ', 'sh': 'tema', 'sl': 'tema',
@@ -772,7 +772,7 @@ class BasicBot(
               'hu': 'nők', 'hr': 'Žene', 'hy': 'Կանայք', 'en': 'Women', }
     # local name for parameter value for: human rights
     hrightsp = {
-            'pl': 'Prawa człowieka', 'sq': 'Të drejtat e njeriut', 'hy': 'Մարդու իրավունքներ', 'az': 'İnsan hüquqları',
+            'pl': 'Prawa człowieka', 'sq': 'Të drejtat e njeriut', 'hy': 'Մարդու իրավունքներ', 'az': 'insan hüquqları',
             'ba': 'Кеше хоҡуҡтары', 'be': 'Правы чалавека', 'be-tarask': 'Правы чалавека', 'sh': 'Ljudska prava',
             'bs': 'Ljudska prava', 'hr': 'Ljudska prava', 'sr': 'Људска права', 'myv': 'Ломанень прават', 'et': 'Inimõigused',
             'ge': 'ადამიანის უფლებები', 'de': 'Menschenrechte', 'el': 'νθρώπινα δικαιώματα', 'hu': 'Emberi jogok',

--- a/ms-CEESpring2024.py
+++ b/ms-CEESpring2024.py
@@ -772,7 +772,7 @@ class BasicBot(
               'hu': 'nők', 'hr': 'Žene', 'hy': 'Կանայք', 'en': 'Women', }
     # local name for parameter value for: human rights
     hrightsp = {
-            'pl': 'Prawa człowieka', 'sq': 'Të drejtat e njeriut', 'hy': 'Մարդու իրավունքներ', 'az': 'insan hüquqları',
+            'pl': 'Prawa człowieka', 'sq': 'Të drejtat e njeriut', 'hy': 'Մարդու իրավունքներ', 'az': 'İnsan hüquqları',
             'ba': 'Кеше хоҡуҡтары', 'be': 'Правы чалавека', 'be-tarask': 'Правы чалавека', 'sh': 'Ljudska prava',
             'bs': 'Ljudska prava', 'hr': 'Ljudska prava', 'sr': 'Људска права', 'myv': 'Ломанень прават', 'et': 'Inimõigused',
             'ge': 'ადამიანის უფლებები', 'de': 'Menschenrechte', 'el': 'νθρώπινα δικαιώματα', 'hu': 'Emberi jogok',


### PR DESCRIPTION
"qadınlar" means "women" in Azerbaijani. I think this is the reason why the articles on the Azerbaijani Wikipedia are not counted on the [general statistics](https://meta.wikimedia.org/wiki/Wikimedia_CEE_Spring_2024/Statistics/Articles_about_Human_Rights/Authors).